### PR TITLE
fix development version link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@ title: Documentation
 <p>
 The technical documentation is updated as future versions of the product are
 being developed. You can find this in-progress documentation
-<a href="version/developer">here</a>, but be warned that it may not reflect
+<a href="version/development">here</a>, but be warned that it may not reflect
 the current features and capabilities of the latest release.
 </p>
 


### PR DESCRIPTION
## Proposed Changes

There was a typo in the link, instead of "development" it was "developer".
