### PR TITLE
emphasize dev docs over release for now

### DIFF
--- a/_data/home.yml
+++ b/_data/home.yml
@@ -17,7 +17,7 @@ why-titan:
 
 features:
   - name: Data versioning
-    description: Version your data like code, commiting and checking the data your need to get your work done.
+    description: Version your data like code, committing and checking the data your need to get your work done.
 
   - name: Any data
     description: Titan works with off-the-shelf docker containers, including your favorite SQL and NoSQL data stores.

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,19 +4,23 @@ title: Documentation
 ---
 
 <div class="action-btns">
-    <a href="version/latest" class="btn btn-primary">Release</a>
-    <a href="version/development" class="btn btn-secondary">Development</a>
+    <a href="version/development" class="btn btn-primary">Development</a>
+    <a href="version/latest" class="btn btn-secondary">Release</a>
 </div>
 
 <h2>Documentation</h2>
 
 <p>
-The technical documentation provides detailed information about Titan, and is
-versioned alongside the tool. The <a href="version/latest">Release
-Documentation</a> above corresponds to the latest stable Titan release. You can
-also consult the in-progress <a href="version/development">Development
-Documentation</a>, but be warned that it may not reflect the current features
-and capabilities of the latest release.
+While the documentation is under initial construction, we advise users to
+consulte the <a href="version/development">development documentation</a> as
+it will have the latest information. The <a href="version/latest">release
+documentation</a> is fixed at the time the release is published.
+</p>
+
+<p>
+Once the initial documentation is complete, the release documentation will be
+a more accurate reflection of what is available in the currently shipping
+version of Titan.
 </p>
 
 <h2>All Versions</h2>

--- a/download.html
+++ b/download.html
@@ -15,7 +15,7 @@ title: Download
            <i class="fab fa-apple fa-lg"></i>
            Mac OS
         </a>
-        <a href="{{ site.data.download.windows }}" class="btn btn-secondary">
+        <a href="{{ site.data.download.windows }}" class="btn btn-primary">
             <i class="fab fa-windows fa-lg"></i>
             Windows
         </a>


### PR DESCRIPTION
## Proposed Changes

While we're in the process of building the initial documentation, we should direct users to the dev docs as they're have changes more recent than the last release. This switches up the button emphasis and adds some more text.

## Testing

Built & viewed locally.