### PR TITLE
include analytics

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,4 +16,19 @@
 
   <link rel="shortcut icon" type="image/png" href="/img/favicon.ico"/>
 
+  <!--
+    Google Analytics. This is currently linked to the personal acocunt of one
+    of the maintainers, with all data sharing turned off. It would be preferable
+    to find a better community-owned solution, but this lets us begin with
+    something as we get the community off the ground.
+  -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-148854697-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-148854697-1');
+  </script>
+
 </head>


### PR DESCRIPTION
## Proposed Changes

As we start to publicly evangelize the community more, it'd be good to understand how users are using our site. Google is not the best long-term answer, as it has to be associated with a personal account (mine, currently) and has extensive data sharing capabilities. But for now, this gives us something to start with, and we can move to a better community-oriented solution in the future. I have disabled all data sharing features within Google Analytics.